### PR TITLE
Inertia-2: remove unneeded hand calcs that don't render

### DIFF
--- a/inertia/inertia-2.ipynb
+++ b/inertia/inertia-2.ipynb
@@ -202,6 +202,9 @@
     "({}^R\\begin{bmatrix}C\\end{bmatrix}^N)^T\n",
     "```\n",
     "where $({}^R\\begin{bmatrix}C\\end{bmatrix}^N)^T$ is the transpose of the DCM of N in R. Equation {eq}`rotationTheoremInertia` is known the `Rotation Theorem for computing inertia matrix'.\n",
+    "\n",
+    "<!--\n",
+    "\n",
     ":::{admonition}Hand-calculations to derive {eq}`rotationTheoremInertia`\n",
     ":class: tip, dropdown\n",
     "\n",
@@ -227,8 +230,9 @@
     "name: 36\n",
     "---\n",
     "```\n",
-    ":::\n",
-    "::::"
+    ":::-->\n",
+    "::::\n",
+    "\n"
    ]
   },
   {


### PR DESCRIPTION
**second attempt at inertia-2, I originally messed up and lumped the inertia 1 and 2 changes into one PR but this has now been closed and fixed into two separate PR's for inertia 1 & 2**

All this PR does is remove unneeded hand calcs as they have been transcribed prior - in the current state they also don't render which makes the book look messy.

see image below 
![image](https://github.com/user-attachments/assets/e350dca3-79d9-4720-a82d-2901a1f90646)
